### PR TITLE
Bump version

### DIFF
--- a/src/moka.app.src
+++ b/src/moka.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang; erlang-indent-level: 2 -*-
 {application, moka,
  [  {description, "Yet another mocking framework"}
-  , {vsn, "1.0.5c"}
+  , {vsn, "1.0.5d"}
   , {registered, []}
   , {applications, [kernel, stdlib, samerlib]}
   , {mod, {moka_app, []}}


### PR DESCRIPTION
It seems like when version `1.0.5d` was tagged, an update to `src/moka.app.src` got missed. Attached commit fixes that.

HTH